### PR TITLE
docs: Add community standards

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,47 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[Bug]: Short description of the issue"
+labels: "bug, needs triage"
+assignees: "@dileepabandara"
+---
+
+## Bug Report
+
+### Description
+
+[Provide a clear and concise description of the bug.]
+
+### Steps to Reproduce
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+### Expected Behavior
+
+[What did you expect to happen?]
+
+### Actual Behavior
+
+[What actually happened?]
+
+### Screenshots
+
+[If applicable, add screenshots to help explain your problem.]
+
+### Environment
+
+[Please add any other relevant information about the bug and remove the unnecessary lines.]
+
+e.g.,
+
+- Operating System: [e.g., Windows, MacOS, Linux]
+- Browser: [e.g., Chrome, Firefox, Safari]
+- Device: [e.g., iPhone6, Laptop]
+- Version: [e.g., 22]
+- Other info: [e.g., Display Resolution, Resolution, etc]
+
+### Additional Information
+
+[Add any other information about the problem here. For example, you might include the error message, any recent changes that you made to the project, or any other relevant details.]

--- a/.github/ISSUE_TEMPLATE/documentation_update.md
+++ b/.github/ISSUE_TEMPLATE/documentation_update.md
@@ -1,0 +1,25 @@
+---
+name: Documentation update
+about: Propose a change to the project documentation
+title: "[Docs]: Short description of the change"
+labels: "documentation, needs review"
+assignees: "@dileepabandara"
+---
+
+## Documentation Update
+
+### Description
+
+[Provide a clear and concise description of the documentation update you'd like to see made.]
+
+### Current Documentation
+
+[Provide a link to the current documentation or describe where it can be found.]
+
+### Proposed Documentation
+
+[Provide a clear and concise description of the updated documentation that you'd like to see added.]
+
+### Additional Information
+
+[Add any other information about the documentation update here. For example, you might include links to similar documentation in other projects, or screenshots or diagrams to help explain your idea.]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature request
+about: Suggest a feature for this project
+title: "[Feature Request]: Short description of the feature"
+labels: "enhancement, needs triage, feature request"
+assignees: "@dileepabandara"
+---
+
+## Feature Request
+
+### Description
+
+[Provide a clear and concise description of the feature you'd like to see added.]
+
+### Use Case
+
+[Describe how this feature would be useful to you or to other users of the project.]
+
+### Proposed Solution
+
+[If you have a specific solution in mind, describe it here. If not, you can skip this section.]
+
+### Alternatives
+
+[Are there any alternative solutions or workarounds that you've considered? If so, describe them here.]
+
+### Additional Information
+
+[Add any other information about the feature request here. For example, you might include links to similar features in other projects, or screenshots or diagrams to help explain your idea.]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+# Pull Request
+
+**Description**
+
+Briefly describe the changes made in this pull request.
+
+**Related Issue(s)**
+
+If this pull request is related to an issue, please reference it by linking to it (e.g., "Closes #123").
+
+**Checklist**
+
+Before submitting this pull request, please ensure the following:
+
+- [ ] I have read and followed the project's contributing guidelines.
+- [ ] My code follows the project's coding style and conventions.
+- [ ] My commits follow the project's commit message guidelines.
+- [ ] I have reviewed my changes to ensure they are complete and accurate.
+
+**Submission**
+
+Before submitting, please review your pull request to ensure it is complete and follows the provided checklist. Thank you for contributing!

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -43,7 +43,7 @@ jobs:
           DEPLOY_URL=$(echo "$DEPLOY_OUTPUT" | jq -r '.deploy_url')
 
           # Set outputs for later use
-          echo "{deploy_url}=${DEPLOY_URL}" >> $GITHUB_OUTPUT
+          echo "deploy_url=${DEPLOY_URL}" >>$GITHUB_OUTPUT
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_PREVIEW_SITE_ID }}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+info@nibmcs.org.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/COMMIT_MESSAGE_GUIDELINES.md
+++ b/COMMIT_MESSAGE_GUIDELINES.md
@@ -1,0 +1,47 @@
+# Commit Message Guidelines
+
+Good commit messages are essential for maintaining a clean and informative Git history. This document provides guidelines for writing clear and meaningful commit messages in this repository.
+
+## Commit Message Structure
+
+A commit message should have a clear and concise structure:
+
+**``<type>(<scope>): <subject>``**
+
+- `<type>`: Describes the purpose of the commit. Common types include:
+  - `feat`: A new feature or functionality.
+  - `fix`: A bug fix.
+  - `docs`: Documentation changes.
+  - `style`: Code style changes (e.g., formatting, whitespace).
+  - `refactor`: Code refactoring without changing functionality.
+  - `test`: Adding or modifying tests.
+  - `chore`: Routine tasks, maintenance, or housekeeping.
+- `<scope>` (optional): Describes the context or component of the project that the commit affects.
+- `<subject>`: A concise one-line description of the commit. It should start with a verb in the imperative mood (e.g., "Fix typo" instead of "Fixed typo" or "Fixes typo").
+
+## Examples
+
+Here are some examples of well-formatted commit messages:
+
+| Type       | Commit Message with Scope                            | Commit Message without Scope                        |
+|------------|-----------------------------------------------------|-----------------------------------------------------|
+| `feat`     | `feat(user-auth): Add user registration functionality` | `feat: Add user registration functionality`         |
+| `fix`      | `fix(api): Handle null values in response`         | `fix: Handle null values in response`               |
+| `docs`     | `docs(readme): Update installation instructions`   | `docs: Update installation instructions`            |
+| `style`    | `style(css): Format code according to style guide` | `style: Format code according to style guide`       |
+| `refactor` | `refactor(database): Optimize query performance`   | `refactor: Optimize query performance`              |
+| `test`     | `test(unit): Add tests for authentication`        | `test: Add tests for authentication`                |
+| `chore`    | `chore(release): Bump version to 1.0.0`            | `chore: Bump version to 1.0.0`                      |
+
+## Additional Guidelines
+
+- Keep commit messages concise and focused on a single change.
+- Use present tense (e.g., "Add feature" not "Added feature").
+- Capitalize the first letter of the subject.
+- Use imperative mood for the subject (e.g., "Fix bug" not "Fixing bug").
+- Use an empty line between the subject and the body (if the body is present).
+- Use the body of the commit message to provide additional context and details if necessary.
+
+## Summary
+
+Writing clear and consistent commit messages helps everyone involved in the project understand the purpose and context of each commit. Following these guidelines will lead to a more organized and understandable Git history.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing to nibmcs.org
+
+Thank you for your interest in contributing to [nibmcs.org](https://github.com/nibmcs/nibmcs.org)! We welcome any contributions, including bug fixes, feature enhancements, documentation improvements, and other general improvements.
+
+## Getting Started
+
+1. Fork this repository to your GitHub account. This will create a copy of this repository in your account. You can make changes to this copy without affecting the original repository.
+   - To fork this repository, click the **Fork** button in the top right corner of this page or click [here](https://github.com/nibmcs/nibmcs.org/fork).
+2. Clone your forked repository to your local machine.
+   - Use the following command to clone your forked repository to your local machine.
+  
+     ```bash
+     git clone https://github.com/your-username/nibmcs.org.git
+     ```
+
+3. Create a new branch for your changes.
+   - For example, to create a new branch named `your-branch-name`, use the following command.
+  
+     ```bash
+     git checkout -b your-branch-name
+     ```
+
+4. Make your changes and commit them with a descriptive commit message.
+   - For example, to commit your changes, use the following command and make sure to follow the [commit message guidelines](COMMIT_GUIDELINES.md).
+  
+     ```bash
+     git commit -m "feat: add a new feature"
+     ```
+
+5. Push your changes to your forked repository.
+   - For example, to push your changes to your forked repository, use the following command.
+  
+     ```bash
+     git push origin your-branch-name
+     ```
+
+6. Submit a **pull request** to the upstream repository.
+   - For example, to create a pull request, use the following steps.
+     1. Go to your forked repository.
+     2. Click the **Compare & pull request** button next to your `your-branch-name` branch.
+     3. Add a title and description for your pull request.
+     4. Click **Create pull request** and remember to add the relevant labels using the [pull request template](.github/PULL_REQUEST_TEMPLATE.md).
+
+## Guidelines
+
+- Follow the code style of the project.
+- Update the **documentation** if necessary.
+- Add tests if applicable.
+- Make sure all tests pass before submitting your changes.
+- Keep your pull request focused and avoid including unrelated changes.
+- Remember to follow the given files before submitting your changes:
+  - [bug_report.md](.github/ISSUE_TEMPLATE/bug_report.md) - Use this template to create a report to help us improve.
+  - [feature_request.md](.github/ISSUE_TEMPLATE/feature_request.md) - Use this template to suggest a feature for this project.
+  - [documentation_update.md](.github/ISSUE_TEMPLATE/documentation_update.md) - Use this template to propose a change to the documentation.
+  - [custom.md](.github/ISSUE_TEMPLATE/custom.md) - Use this template to submit a custom issue.
+  - [PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) - Use this template to submit a pull request.
+  - [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) - Read this file to learn about the code of conduct.
+  - [COMMIT_MESSAGE_GUIDELINES.md](COMMIT_MESSAGE_GUIDELINES.md) - Read this file to learn about the commit message guidelines.
+  - [CONTRIBUTING.md](CONTRIBUTING.md) - Read this file to learn about the contributing guidelines.
+  - [LICENSE](LICENSE) - Read this file to learn about the license.
+  - [README.md](README.md) - Read this file to learn about the project.
+  - [SECURITY.md](SECURITY.md) - Read this file to learn about the security policy.
+
+## Code of Conduct
+
+Please note that this project adheres to the **Contributor Covenant Code of Conduct**. By participating in this project, you agree to abide by its terms.
+
+Read the full code of conduct [here](CODE_OF_CONDUCT.md).
+
+## Contact
+
+If you have any questions, feel free to contact us via email at <contact@nibmcs.org>.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 NIBM Computing Society
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
I've added the following files and templates to our project:

- bug_report.md - Use this template to create a report to help us improve.
- feature_request.md - Use this template to suggest a feature for this project.
- documentation_update.md - Use this template to propose a change to the documentation.
- PULL_REQUEST_TEMPLATE.md - Use this template to submit a pull request.
- CODE_OF_CONDUCT.md - Read this file to learn about the code of conduct.
- COMMIT_MESSAGE_GUIDELINES.md - Read this file to learn about the commit message guidelines.
- CONTRIBUTING.md - Read this file to learn about the contributing guidelines.
- LICENSE - Read this file to learn about the license.

